### PR TITLE
add generator for search-objects

### DIFF
--- a/lib/generators/gql/model_search_base_generator.rb
+++ b/lib/generators/gql/model_search_base_generator.rb
@@ -1,0 +1,9 @@
+module Gql
+  class ModelSearchBaseGenerator < Rails::Generators::Base          
+    source_root File.expand_path('../templates', __FILE__)    
+    def generate_model_search_base
+      gem 'search_object_graphql'    
+      template('model_search_base.rb', "app/graphql/resolvers/base_search_resolver.rb")
+    end
+  end
+end

--- a/lib/generators/gql/model_search_generator.rb
+++ b/lib/generators/gql/model_search_generator.rb
@@ -1,0 +1,19 @@
+require_relative 'gql_generator_base'
+module Gql
+  class ModelSearchGenerator < Rails::Generators::Base
+    include GqlGeneratorBase
+    source_root File.expand_path('../templates', __FILE__)
+    argument :model_name, type: :string
+
+    def search
+      inject_into_file(
+        "app/graphql/types/query_type.rb", 
+        "\t\tfield :#{model_name.downcase.pluralize}, resolver: Resolvers::#{model_name}Search \n", 
+        :after => "class QueryType < Types::BaseObject\n"
+      )
+      file_name = "#{model_name.underscore}_search"
+      @fields = map_model_types(model_name)
+      template('model_search.rb', "app/graphql/resolvers/#{file_name}.rb")
+    end
+  end
+end

--- a/lib/generators/gql/templates/model_search.rb
+++ b/lib/generators/gql/templates/model_search.rb
@@ -1,0 +1,16 @@
+module Resolvers
+  class <%= @resolver_prefix %><%= @model_name %>Search < Resolvers::BaseSearchResolver
+    type [Types::<%= @model_name %>Type], null: false
+    description "Lists <%= @model_name.downcase.pluralize %>"
+
+    scope { <%= @model_name %>.all }
+  
+  <% @fields.each do |field| -%>
+  option(:<%= field[:name] %>, type: <%= field[:gql_type] %>)   { |scope, value| scope.where <%= field[:name] %>: value }
+  <% end %>
+    def resolve
+      []
+    end
+
+  end
+end

--- a/lib/generators/gql/templates/model_search_base.rb
+++ b/lib/generators/gql/templates/model_search_base.rb
@@ -1,0 +1,7 @@
+module Resolvers
+  class BaseSearchResolver < GraphQL::Schema::Resolver
+    require 'search_object'
+    require 'search_object/plugin/graphql'
+    include SearchObject.module(:graphql)
+  end
+end


### PR DESCRIPTION
A generator for a "search object" based on [SearchObject](https://github.com/RStankov/SearchObject) . With this we can quickly generate a search object, to which we can pass through any model field arguments (by default) into the search object resolver, and it will handle the logic for ignoring nil arguments and chaining the scopes etc... ]

add search_object_graphql_dependency
create base search resolver generator
inject field into query_type file
update readme