### PR TITLE
Fix the default options of model_type and input generators

### DIFF
--- a/lib/generators/gql/input_generator.rb
+++ b/lib/generators/gql/input_generator.rb
@@ -12,7 +12,7 @@ module Gql
     class_option :namespace, type: :string, default: 'Types::Input'
 
     def generate_input_type
-      name = options['name'] || model_name
+      name = options['name'].nil? ? "#{model_name}Input" : options['name']
       superclass = options['superclass']
 
       ignore = ['id', 'created_at', 'updated_at']
@@ -23,7 +23,7 @@ module Gql
       end
 
       code = class_with_fields(options['namespace'], name, superclass, fields)
-      file_name = File.join(root_directory(options['namespace']), "#{name.underscore}_input.rb")
+      file_name = File.join(root_directory(options['namespace']), "#{name.underscore}.rb")
 
       create_file file_name, code
     end

--- a/lib/generators/gql/model_type_generator.rb
+++ b/lib/generators/gql/model_type_generator.rb
@@ -12,7 +12,7 @@ module Gql
     class_option :namespace, type: :string, default: 'Types'
 
     def type
-      name = options['name'] || model_name
+      name = options['name'].nil? ? "#{model_name}Type" : options['name']
 
       superclass = options['superclass']
 
@@ -22,7 +22,7 @@ module Gql
       end
 
       code = class_with_fields(options['namespace'], name, superclass, fields)
-      file_name = File.join(root_directory(options['namespace']), "#{name.underscore}_type.rb")
+      file_name = File.join(root_directory(options['namespace']), "#{name.underscore}.rb")
 
       create_file file_name, code
     end


### PR DESCRIPTION
By default, the `model_type` and `input` generators should generate class and file names suffixed by 'model' or 'input', respectively. They should allow over-writing the generated class/file name via the `--name` option for people who want to break from the graphql-ruby generator conventions.