### PR TITLE
Fix generation of input types

### DIFF
--- a/lib/generators/gql/gql_generator_base.rb
+++ b/lib/generators/gql/gql_generator_base.rb
@@ -68,5 +68,19 @@ module Gql
         klass.join("\n")
       end
     end
+
+    def class_with_arguments(namespace, name, superclass, fields)
+      wrap_in_namespace(namespace) do |indent|
+        klass = []
+        klass << sprintf("%sclass %s < %s", "  " * indent, name, superclass)
+
+        fields.each do |field|
+          klass << sprintf("%sargument :%s, %s, required: %s", "  " * (indent + 1), field[:name], field[:gql_type], !field[:null])
+        end
+
+        klass << sprintf("%send", "  " * indent)
+        klass.join("\n")
+      end
+    end
   end
 end

--- a/lib/generators/gql/input_generator.rb
+++ b/lib/generators/gql/input_generator.rb
@@ -22,7 +22,7 @@ module Gql
         fields.reject! { |field| !options['include_columns'].include?(field[:name]) }
       end
 
-      code = class_with_fields(options['namespace'], name, superclass, fields)
+      code = class_with_arguments(options['namespace'], name, superclass, fields)
       file_name = File.join(root_directory(options['namespace']), "#{name.underscore}.rb")
 
       create_file file_name, code


### PR DESCRIPTION
Input types generation is wrong, like also noticed in this issue #12 

Input type fields should be like:
```
argument :id, Integer, required: false
```

Classes are actually generated like:
```
field :id, Integer, null: true
```

This PR should fix that.